### PR TITLE
fix: tell user if no zone found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Unreleased changes. Release notes have not yet been written.
 
+- tell user if no zone found
+
 # 0.1.5 (2021-04-08)
 
 This release include fixes for creates.io workflow.

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn run() -> Result<()> {
             Ok(res) => {
                 let print_output = |rr_type: String, name: String, rdata: String| {
                     println!(
-                        "  {0: <15} {1: <15} {2: <10}",
+                        "  {} {} {}",
                         rr_type.green().bold(),
                         name.blue(),
                         rdata.bold()

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,20 @@ fn run() -> Result<()> {
                     );
                 };
 
-                for res in res.answers() {
-                    let rr_type = res.rr_type().to_string();
-                    print_output(rr_type, res.name().to_string(), res.rdata().to_string());
-                }
-                for res in res.name_servers() {
-                    let rr_type = res.rr_type().to_string();
-                    print_output(rr_type, res.name().to_string(), res.rdata().to_string());
+                if !res.answers().is_empty() {
+                    for res in res.answers() {
+                        let rr_type = res.rr_type().to_string();
+                        print_output(rr_type, res.name().to_string(), res.rdata().to_string());
+                    }
+                } else if res.answers().is_empty() && !res.name_servers().is_empty() {
+                    // if answers is empty, print default record (SOA)
+                    for res in res.name_servers() {
+                        let rr_type = res.rr_type().to_string();
+                        print_output(rr_type, res.name().to_string(), res.rdata().to_string());
+                    }
+                } else {
+                    // if default doesn't exist
+                    println!("{}", "  No zone found".to_string().red());
                 }
             }
         }


### PR DESCRIPTION
If the target record is not found, show the default record (SOA).
Otherwise, it's no zone.